### PR TITLE
(#18) 대회 관리 페이지 퍼블리싱

### DIFF
--- a/src/Router/Router.tsx
+++ b/src/Router/Router.tsx
@@ -13,6 +13,7 @@ import MainStudent from "../pages/main/Main_Student";
 import ContestComponent from "../components/main/Contest";
 import MainTeacher from "../pages/main/Main_Teacher";
 import PersonManagement from "../pages/Admin/PersonManagement";
+import ContestManagement from "../pages/Admin/ContestManagement"
 
 
 export default function Router() {
@@ -31,6 +32,7 @@ export default function Router() {
         <Route path="/MainStudent" element={<MainStudent />} />
         <Route path="/MainTeacher" element={<MainTeacher />} />
         <Route path="PersonManagement" element={<PersonManagement/>}/>
+        <Route path="ContestManagement" element={<ContestManagement/>}/>
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/Admin/ManagementTitleWrap.tsx
+++ b/src/components/Admin/ManagementTitleWrap.tsx
@@ -3,19 +3,34 @@ import styled from "styled-components";
 import DocumentButton from "../../components/Admin/DocumentButton";
 import { Plus, Exchange } from "../../assets/Admin";
 
-export default function ManagementTitleWrap() {
+interface PropsType {
+    id?: string,
+    title?: string
+    info?: string
+}
+
+export default function ManagementTitleWrap({ id, title, info }: PropsType) {
 
     return (
-        <Container>
-            <TitleAndInfo>
-                <Title>인원 정보 관리</Title>
-                <SubInfo>학생 정보를 편집하고 관리할 수 있어요</SubInfo>
-            </TitleAndInfo>
-            <TitleAndInfo>
-                <DocumentButton icon={Plus} text="인원 문서로 추가하기" />
-                <DocumentButton icon={Exchange} text="인원 문서로 수정하기" />
-            </TitleAndInfo>
-        </Container>
+        <>
+            <Container>
+                <TitleAndInfo>
+                    <Title>{title}</Title>
+                    <SubInfo>{info}</SubInfo>
+                </TitleAndInfo>
+                <TitleAndInfo>
+                    {id === "person" && (
+                        <>
+                            <DocumentButton icon={Plus} text="인원 문서로 추가하기" />
+                            <DocumentButton icon={Exchange} text="인원 문서로 수정하기" />
+                        </>
+                    )}
+                    {id === "contest" && (
+                        <DocumentButton icon={Plus} text="대회 추가하기" />
+                    )}
+                </TitleAndInfo>
+            </Container>
+        </>
     )
 }
 
@@ -36,7 +51,7 @@ font-size: 28px;
 `
 
 const SubInfo = styled.p`
-font-family: "Pretendard-Semibold";
+font-family: "Pretendard-Medium";
 font-size: 14px;
 color: #8C8C8C;
 

--- a/src/components/Admin/TableButton.tsx
+++ b/src/components/Admin/TableButton.tsx
@@ -3,19 +3,25 @@ import styled from "styled-components";
 
 interface PropsType {
     text?: string
+    color?: string
 }
 
-export default function TableButton({text} : PropsType) {
+interface ButtonProps {
+    color?: string
+}
+
+export default function TableButton({text, color} : PropsType) {
     return (
-        <Button>{text}</Button>
+        <Button color={color}>{text}</Button>
     )
 }
 
-const Button = styled.button`
+const Button = styled.button<ButtonProps>`
 padding: 4px 20px;
 border: none;
 border-radius: 12px;
 font-family: "Pretendard-Medium";
 font-size: 14px;
-color: #474747;
+color: ${(props) => (props.color? "#ffffff" : "#474747")};
+background-color: ${(props) => props.color || "#F2F2F2"};
 `

--- a/src/constants/Admin.ts
+++ b/src/constants/Admin.ts
@@ -1,4 +1,4 @@
-import { SelectValueType, ManagementTableValueType, UserDataType } from "../models/Admin"
+import { SelectValueType, UserDataType, ContestDataType } from "../models/Admin"
 
 export const SelectValue: SelectValueType[] = [
     {
@@ -22,30 +22,6 @@ export const SelectValue: SelectValueType[] = [
         placeholder: "상태 선택하기",
         options: ["재학생", "졸업생", "유급", "전학", "휴학", "자퇴"]
     },
-]
-
-export const PersonTableValue: ManagementTableValueType[] = [
-    {
-        name: "Person Management Table",
-        id: "person",
-        label: ["학년", "반", "번호", "이름", "상태"],
-    }
-]
-
-export const ClubTableValue: ManagementTableValueType[] = [
-    {
-        name: "Club Management Table",
-        id: "club",
-        label: ["현상태", "동아리명"],
-    }
-]
-
-export const ContestTableValue: ManagementTableValueType[] = [
-    {
-        name: "Contest Management Table",
-        id: "contest",
-        label: ["일정", "진행상황"],
-    }
 ]
 
 export const UserData: UserDataType[] = [
@@ -73,4 +49,22 @@ export const UserData: UserDataType[] = [
         name : "홍길남",
         status : "ENROLL"
       }
+]
+
+export const ContestData: ContestDataType[] = [
+    {
+        name: "대마고 대회",
+        status: "시상대기",
+        date: "2024-08-19 ~ 2024-08-19"
+    },
+    {
+        name: "대덕소프트웨어마이스터고등학교대회",
+        status: "시상대기",
+        date: "2024-08-19 ~ 2024-08-19"
+    },
+    {
+        name: "교내해커톤 2024",
+        status: "시상대기",
+        date: "2024-08-19 ~ 2024-08-19"
+    },
 ]

--- a/src/models/Admin.ts
+++ b/src/models/Admin.ts
@@ -6,12 +6,6 @@ export interface SelectValueType {
     options?: Array<string | number>
 }
 
-export interface ManagementTableValueType {
-    name?: string,
-    id?: string,
-    label?: Array<string>,
-}
-
 export interface UserDataType {
     person_id?: number,
     grade?: number,
@@ -19,4 +13,10 @@ export interface UserDataType {
     number?: number,
     name?: string,
     status?: string
+}
+
+export interface ContestDataType {
+    status?: string,
+    name?: string,
+    date?: string,
 }

--- a/src/pages/Admin/ContestManagement.tsx
+++ b/src/pages/Admin/ContestManagement.tsx
@@ -1,0 +1,169 @@
+import React from "react";
+import styled from "styled-components";
+import ManagementTitleWrap from "../../components/Admin/ManagementTitleWrap";
+import { ContestData } from "../../constants/Admin"
+import TableButton from "../../components/Admin/TableButton"
+
+export default function ContestManagement() {
+
+    const LabelValue = ["대회명", "진행상황", "대회일정"]
+
+    return (
+        <Container>
+            <Contents>
+                <ManagementTitleWrap
+                    id="contest"
+                    title="대회 관리"
+                    info="대회를 개최하고 진행 및 관리할 수 있어요"
+                />
+
+                <RecentContestWrap>
+                    <TextRecentView>최근 대회 바로보기 (시상 대기)</TextRecentView>
+                    <RecentBox>
+                        <ContestInfo>
+                            <ContestName>2024 교내 해커톤</ContestName>
+                            <Date>2024.01.01 ~ 2024.01.03</Date>
+                        </ContestInfo>
+                        <TableButton text="시상하기" color="#1F62E4" />
+                    </RecentBox>
+                </RecentContestWrap>
+
+                <TableContainer>
+                    <TableHeader>
+                        <UserDataWrap>
+                            {LabelValue.map((value, index) => (
+                                <Label>{value}</Label>
+                            ))}
+                        </UserDataWrap>
+                    </TableHeader>
+
+                    <TableDataWrap>
+                        {ContestData.map((value, index) => (
+                            <Row key={index} >
+
+                                <UserDataWrap>
+                                    <Text>{value.name}</Text>
+                                    <State>{value.status}</State>
+                                    <Text>{value.date}</Text>
+                                </UserDataWrap>
+
+                                <TableButton text="수정하기" />
+                            </Row>
+                        ))}
+                    </TableDataWrap>
+                </TableContainer>
+
+            </Contents>
+        </Container>
+    )
+}
+
+const Container = styled.div`
+width: 100%;
+display: flex;
+justify-content: center;
+`
+
+const Contents = styled.div`
+width: 70vw;
+display: flex;
+flex-direction: column;
+gap: 40px;
+`
+
+const RecentContestWrap = styled.div`
+display: flex;
+flex-direction: column;
+gap: 8px;
+`
+
+const RecentBox = styled.div`
+display: flex;
+justify-content: space-between;
+align-items: center;
+border: 1px solid #D1D1D1;
+border-radius: 8px;
+padding: 12px 30px;
+`
+
+const ContestInfo = styled.div`
+display: flex;
+align-items: flex-end;
+gap: 8px;
+`
+
+const TableContainer = styled.div`
+display: flex;
+flex-direction: column;
+gap: 12px;
+`
+
+const TableHeader = styled.div`
+display: flex;
+flex: 2 1 1;
+background-color: #0047D2;
+padding: 12px 48px;
+border-radius: 8px;
+`
+
+const TableDataWrap = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+`
+
+const Row = styled.div`
+display: flex;
+justify-content: space-between;
+padding: 12px 48px;
+border-bottom: 1px solid #D1D1D1;
+`
+
+const UserDataWrap = styled.div`
+width: 70%;
+display: flex;
+`
+
+const TextRecentView = styled.p`
+font-family: "Pretendard-Medium";
+font-size: 16px;
+color: #474747;
+`
+
+const ContestName = styled.p`
+font-family: "Pretendard-Medium";
+font-size: 16px;
+`
+
+const Date = styled.p`
+font-family: "Pretendard-regular";
+font-size: 14px;
+color: #474747;
+`
+
+const Label = styled.p`
+font-family: "Pretendard-Medium";
+font-size: 16px;
+color: #ffffff;
+flex: 1;
+text-align: center;
+`
+
+const Text = styled.p`
+font-family: "Pretendard-regular";
+font-size: 16px;
+color: #474747;
+flex: 1;
+text-align: center;
+overflow: hidden;
+text-overflow: ellipsis; 
+white-space: nowrap;
+`
+
+const State = styled.p`
+font-family: "Pretendard-regular";
+font-size: 16px;
+color: #1D5AD0;
+flex: 1;
+text-align: center;
+`

--- a/src/pages/Admin/PersonManagement.tsx
+++ b/src/pages/Admin/PersonManagement.tsx
@@ -4,7 +4,7 @@ import ManagementTitleWrap from "../../components/Admin/ManagementTitleWrap";
 import SelectBox from "../../components/Admin/SelectBox";
 import Search from "../../components/Admin/Search";
 import TableButton from "../../components/Admin/TableButton"
-import { SelectValue, PersonTableValue, UserData } from "../../constants/Admin"
+import { SelectValue, UserData } from "../../constants/Admin"
 import { Reset } from "../../assets/Admin"
 
 export default function PersonManagement() {
@@ -14,7 +14,11 @@ export default function PersonManagement() {
     return (
         <Container>
             <Contents>
-                <ManagementTitleWrap />
+                <ManagementTitleWrap
+                    id="person"
+                    title="인원 정보 관리"
+                    info="학생 정보를 편집하고 관리할 수 있어요"
+                />
 
                 <FilterWrap>
                     {
@@ -114,6 +118,7 @@ const Row = styled.div`
 display: flex;
 justify-content: space-between;
 padding: 12px 48px;
+border-bottom: 1px solid #D1D1D1;
 `
 
 const UserDataWrap = styled.div`
@@ -123,7 +128,6 @@ display: flex;
 
 const Label = styled.p`
 flex: 1;
-
 font-family: "Pretendard-Medium";
 font-size: 16px;
 color: #ffffff;


### PR DESCRIPTION
테이블 데이터 위치가 변경되었습니다

피그마 상에서는 일정 - 대회상태 - 대회명 으로 되어있지만
웹 상에서는 보기 불편해서 대회명 - 일정 - 대회상태 이렇게 변경했어요!

---

대회 상태마다 나타나는 버튼은 연동 하면서 고치도록 하겠습니다람쥐